### PR TITLE
Set height to enable virtualization. Collapse groups by default.

### DIFF
--- a/BlazorWasmAppRadzen/Pages/FetchData.razor
+++ b/BlazorWasmAppRadzen/Pages/FetchData.razor
@@ -5,7 +5,7 @@
 <PageTitle>Weather forecast</PageTitle>
 
 <RadzenDataGrid AllowGrouping="true" AllowVirtualization=@true
-    Style="height: 500px"
+    Style="height: 800px; width: 100%"
     Count="@WeatherForecast.Data.Length"
     Data="@forecasts" TItem="WeatherForecast" ColumnWidth="160px" HideGroupedColumn="true" GroupRowRender=@OnGroupRowRender GroupRowCollapse="OnGroupRowCollapse" GroupRowExpand="OnGroupRowExpand">
     <Columns>

--- a/BlazorWasmAppRadzen/Pages/FetchData.razor
+++ b/BlazorWasmAppRadzen/Pages/FetchData.razor
@@ -4,8 +4,10 @@
 
 <PageTitle>Weather forecast</PageTitle>
 
-<RadzenDataGrid forecasts AllowGrouping="true" PageSize=@WeatherForecast.Data.Length AllowVirtualization=@true
-                Data="@forecasts" TItem="WeatherForecast" ColumnWidth="160px" HideGroupedColumn="true" Vi>
+<RadzenDataGrid AllowGrouping="true" AllowVirtualization=@true
+    Style="height: 500px"
+    Count="@WeatherForecast.Data.Length"
+    Data="@forecasts" TItem="WeatherForecast" ColumnWidth="160px" HideGroupedColumn="true" GroupRowRender=@OnGroupRowRender GroupRowCollapse="OnGroupRowCollapse" GroupRowExpand="OnGroupRowExpand">
     <Columns>
         <RadzenDataGridColumn TItem="WeatherForecast" Property=@nameof(WeatherForecast.LastRendered) Title="Last rendered" />
 		<RadzenDataGridColumn TItem="WeatherForecast" Property=@nameof(WeatherForecast.Date) Title="Date" />

--- a/BlazorWasmAppRadzen/Pages/FetchData.razor.cs
+++ b/BlazorWasmAppRadzen/Pages/FetchData.razor.cs
@@ -1,14 +1,34 @@
 using CSharpSharedData;
+using Radzen;
 
 namespace BlazorWasmAppRadzen.Pages
 {
-   public partial class FetchData
-   {
-      private WeatherForecast[]? forecasts;
+    public partial class FetchData
+    {
+        private WeatherForecast[]? forecasts;
+        private HashSet<object> expanded = new ();
 
-      protected override void OnInitialized()
-      {
-         forecasts = WeatherForecast.Data;
-      }
-   }
+        protected override void OnInitialized()
+        {
+            forecasts = WeatherForecast.Data;
+        }
+
+        void OnGroupRowRender(GroupRowRenderEventArgs args)
+        {
+            if (!expanded.Contains(args.Group.Data.Key))
+            {
+                args.Expanded = false;
+            }
+        }
+
+        void OnGroupRowExpand(Group args)
+        {
+            expanded.Add(args.Data.Key);
+        }
+
+        void OnGroupRowCollapse(Group args)
+        {
+            expanded.Remove(args.Data.Key);
+        }
+    }
 }


### PR DESCRIPTION
This PR does two things:
1. Sets the height of RadzenDataGrid via `style="height:500px"` so the inner Virtualize panel does its magic.
2. Collapses groups by default as other grids seem to do so in the comparison.